### PR TITLE
Changes to preprocess

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -30,15 +30,18 @@ def create_doc_for_company(labels: dict, company: dict, nlp: Language, multi_lab
     :param multi_label (bool): Whether to use multi-label classification.
     :return (spacy.Doc): Processed Doc object.
     """
-    data = str()
+    text = str()
     
     """
     Concatenate all data points (data per url) into one document per company
     """
     for data_point in company["data"]:
-        data = f"{data} {data_point["data"]}"
+        text = f"{text} {data_point["data"]}"
     
-    doc = nlp.make_doc(data)
+    if len(text) >= 1000000:
+        text = text[:1000000]
+    
+    doc = nlp.make_doc(text)
     
     if multi_label:
         for company_code in company["branch_codes"]:

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -36,7 +36,7 @@ def create_doc_for_company(labels: dict, company: dict, nlp: Language, multi_lab
     Concatenate all data points (data per url) into one document per company
     """
     for data_point in company["data"]:
-        data += data_point["data"]
+        data = f"{data} {data_point["data"]}"
     
     doc = nlp.make_doc(data)
     


### PR DESCRIPTION
- Previous implementation made a document for each data-point of each company, i.e. one document per scraped url. Now each data-point is concatenated into one document per company.
- Dictionary was passed by reference, each call to create_doc_for_company made changes to same dictionary. Fixed by making a copy for each company.