### PR TITLE
Scrapy limit items per domain

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -20,6 +20,7 @@ vars:
     regenerate_company_urls: false
     percentage_dev: 50
     google_limit: 2
+    scrapy_limit: 2
 
 # These are the directories that the project needs. The project CLI will make
 # sure that they always exist.
@@ -94,7 +95,7 @@ commands:
     - name: "scrape"
       help: "Scrapes websites"
       script:
-          - "python scripts/scraping_wrapper.py assets/${vars.scraped_data_file_name}.json"
+          - "python scripts/scraping_wrapper.py assets/${vars.scraped_data_file_name}.json ${vars.scrapy_limit}"
       deps:
           - "scripts/scraping_wrapper.py"
       outputs:

--- a/scraping/NLPspider/spiders/crawlingNLP.py
+++ b/scraping/NLPspider/spiders/crawlingNLP.py
@@ -23,7 +23,11 @@ class CrawlingnlpSpider(CrawlSpider):
             *args: Variable length argument list.
             **kwargs: Arbitrary keyword arguments.
                 start_urls (str): Comma-separated list of URLs to start crawling from.
+                max_items_per_domain (int): The maximum number of items to scrape per domain.
         """
+        self.item_count_per_domain = dict()
+        self.max_items_per_domain = int(kwargs.get("item_limit", 1))
+        
         super(CrawlingnlpSpider, self).__init__(*args, **kwargs)
 
         self.start_urls = kwargs.get("start_urls").split(
@@ -72,6 +76,11 @@ class CrawlingnlpSpider(CrawlSpider):
             item['domain'] = f'{tldextract.extract(response.url).domain}.{tldextract.extract(response.url).suffix}'
             item["url"] = response.url
             item["raw_html"] = response.text
+
+            # Check if the domain has reached the maximum number of items
+            if self.item_count_per_domain.get(item['domain'], 0) >= int(self.max_items_per_domain):
+                return
+            self.item_count_per_domain[item['domain']] = int(self.item_count_per_domain.get(item['domain'], 0) + 1)
 
             yield item
         except Exception as e:

--- a/scraping/NLPspider/spiders/crawlingNLP.py
+++ b/scraping/NLPspider/spiders/crawlingNLP.py
@@ -76,9 +76,15 @@ class CrawlingnlpSpider(CrawlSpider):
             item['domain'] = f'{tldextract.extract(response.url).domain}.{tldextract.extract(response.url).suffix}'
             item["url"] = response.url
             item["raw_html"] = response.text
+            
+            # If the respone url contains "/en/" the item is not yielded
+            if "/en/" in item["url"]:
+                self.logger.info(f"Skipping {item['url']} because it is in English")
+                return
 
             # Check if the domain has reached the maximum number of items
             if self.item_count_per_domain.get(item['domain'], 0) >= int(self.max_items_per_domain):
+                self.logger.debug(f"Skipping {item['url']} because the domain has reached the maximum number of items")
                 return
             self.item_count_per_domain[item['domain']] = int(self.item_count_per_domain.get(item['domain'], 0) + 1)
 

--- a/scripts/scraping_wrapper.py
+++ b/scripts/scraping_wrapper.py
@@ -48,8 +48,10 @@ def main(
             else:
                 start_urls += f'{company["url"]},'
             
-            
-
+        # Check if ouput file exists, then delete it
+        file = Path(output_path).with_suffix(".json")
+        if file.exists():
+            file.unlink()
 
         output_path = Path(ROOT_DIR) / Path(output_path)
         command = f'scrapy crawl crawlingNLP -a start_urls={start_urls} -a item_limit={item_limit} -o {output_path}:json'.split(" ")

--- a/scripts/scraping_wrapper.py
+++ b/scripts/scraping_wrapper.py
@@ -27,6 +27,9 @@ def main(
             formats=["json"], 
             help="The path to the output data file."
             )],
+        item_limit: Annotated[int, typer.Argument(
+            help="The maximum number of items to scrape per domain."
+        )]
         ):
         client = get_client()
         query = {"url": {"$regex": r"/\S"}}
@@ -49,7 +52,7 @@ def main(
 
 
         output_path = Path(ROOT_DIR) / Path(output_path)
-        command = f'scrapy crawl crawlingNLP -a start_urls={start_urls} -o {output_path}:json'.split(" ")
+        command = f'scrapy crawl crawlingNLP -a start_urls={start_urls} -a item_limit={item_limit} -o {output_path}:json'.split(" ")
         logging.info("Running Scrapy crawler with the following command: %s", " ".join(command))
         subprocess.check_call(command, cwd=Path('scraping'))
     

--- a/scripts/scraping_wrapper.py
+++ b/scripts/scraping_wrapper.py
@@ -29,7 +29,7 @@ def main(
             )],
         item_limit: Annotated[int, typer.Argument(
             help="The maximum number of items to scrape per domain."
-        )]
+        )] = 1
         ):
         client = get_client()
         query = {"url": {"$regex": r"/\S"}}


### PR DESCRIPTION
- Scrapy spider now only yields the number of items specified by the variable "scrapy_limit" in project.yml, defaults to 1.
- Does not yield items in English based on url: if it contains "/en/".